### PR TITLE
Use Node.js LTS

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '12'
+          node-version: '18.16.1'
       - uses: actions/cache@v3
         with:
           path: ~/.npm


### PR DESCRIPTION
In the format.yml workflow, bump the version of Node.js to the LTS version from 12.