### PR TITLE
chore: Dependabot cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: "saturday"
       time: "00:00"
       timezone: "Etc/UTC"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -14,3 +16,5 @@ updates:
       day: "saturday"
       time: "00:00"
       timezone: "Etc/UTC"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Wait a week before updating npm dependencies or GitHub Actions.